### PR TITLE
Vectorize jholiday-related functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,16 +2,15 @@ Package: zipangu
 Title: Japanese Utility Functions and Data
 Version: 0.2.0.9000
 Authors@R: 
-    person(given = "Shinya",
-           family = "Uryu",
-           role = c("aut", "cre"),
-           email = "suika1127@gmail.com",
-           comment = c(ORCID = "0000-0002-0493-6186")),
-    person(given = "Hiroaki",
-           family = "Yutani",
-           role = "ctb",
-           email = "yutani.ini@gmail.com",
-           comment = c(ORCID = "0000-0002-3385-7233"))
+    c(person(given = "Shinya",
+             family = "Uryu",
+             role = c("aut", "cre"),
+             email = "suika1127@gmail.com",
+             comment = c(ORCID = "0000-0002-0493-6186")),
+      person(given = "Hiroaki",
+             family = "Yutani",
+             role = "ctb",
+             comment = c(ORCID = "0000-0002-3385-7233")))
 Description: Some data treated by the Japanese R user require
     unique operations and processing. These are caused by address, Kanji,
     and traditional year representations.  'zipangu' transforms specific

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,12 @@ Authors@R:
            family = "Uryu",
            role = c("aut", "cre"),
            email = "suika1127@gmail.com",
-           comment = c(ORCID = "0000-0002-0493-6186"))
+           comment = c(ORCID = "0000-0002-0493-6186")),
+    person(given = "Hiroaki",
+           family = "Yutani",
+           role = "ctb",
+           email = "yutani.ini@gmail.com",
+           comment = c(ORCID = "0000-0002-3385-7233"))
 Description: Some data treated by the Japanese R user require
     unique operations and processing. These are caused by address, Kanji,
     and traditional year representations.  'zipangu' transforms specific

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # zipangu (development version)
 
+* `find_date_by_wday()`, `jholiday_spec()`, `jholiday()`, and `is_jholiday()`
+  are now vectorized and accept multiple `year`s (@yutannihilation, #15).
+
 # zipangu 0.2.0
 
 * Added several functions to handle postal code data.

--- a/R/jholiday.R
+++ b/R/jholiday.R
@@ -22,83 +22,83 @@ jholiday_spec <- function(year, name, lang = "en") {
     if (!name %in% jholiday_names) {
       rlang::abort(sprintf("No such holiday: %s", name))
     }
-    res <-
-      dplyr::case_when(
-        # New Year's Day
-        name == jholiday_names[1] ~
-          lubridate::make_date(year, 1, 1),
-        # Coming of Age Day
-        name == jholiday_names[2] ~
-          dplyr::if_else(
-            year >= 2000,
-            find_date_by_wday(year, 1, 2, 2),
-            lubridate::ymd(paste0(year, "0115"))
-          ),
-        # Foundation Day
-        name == jholiday_names[3] ~
-          dplyr::if_else(
-            year >= 1967,
-            lubridate::ymd(paste0(year, "0211")),
-            lubridate::as_date(NA_character_)
-          ),
-        # Vernal Equinox Day
-        name == jholiday_names[4] ~
-          lubridate::make_date(year, 3, day = shunbun_day(year)),
-        # Showa Day (2007-), Greenery Day (1989-2006), and The Emperor's Birthday (-1989)
-        (name == jholiday_names[5] & year >= 2007) |
-          (name == jholiday_names[6] & dplyr::between(year, 1989, 2006)) |
-          (name == jholiday_names[7] & year < 1989) ~
-            lubridate::make_date(year, 4, 29),
-        # Constitution Memorial Day
-        name == jholiday_names[8] ~
-          lubridate::make_date(year, 5, 3),
-        # Greenery Day (2007-), and Citizens' Holiday (1988-2006)
-        (name == jholiday_names[9] & year >= 2007) |
-          (name == jholiday_names[10] & dplyr::between(year, 1988, 2006)) ~
-          lubridate::make_date(year, 5, 4),
-        # Children's Day
-        name == jholiday_names[11] & year >= 1949 ~
-          lubridate::make_date(year, 5, 5),
-        # Marine Day
-        name == jholiday_names[12] & year == 2020 ~
-          lubridate::as_date("20200723"),
-        name == jholiday_names[12] & year >= 2003 & year != 2020 ~
-          find_date_by_wday(year, 7, 2, 3),
-        name == jholiday_names[12] & dplyr::between(year, 1996, 2002) ~
-          lubridate::make_date(year, 7, 20),
-        # Mountain Day
-        name == jholiday_names[13] & year == 2020 ~
-          lubridate::as_date("20200810"),
-        name == jholiday_names[13] & year >= 2016 & year != 2020 ~
-          lubridate::make_date(year, 8, 11),
-        # Respect for the Aged Day
-        name == jholiday_names[14] & dplyr::between(year, 1966, 2002) ~
-          lubridate::make_date(year, 9, 15),
-        name == jholiday_names[14] & year >= 2003 ~
-          find_date_by_wday(year, 9, 2, 3),
-        # Autumnal Equinox Day
-        name == jholiday_names[15] ~
-          lubridate::make_date(year, 9, day = shubun_day(year)),
-        # Sports Day
-        name == jholiday_names[17] & year == 2020 ~
-          lubridate::as_date("20200724"),
+    dplyr::case_when(
+      # New Year's Day
+      name == jholiday_names[1] ~
+        lubridate::make_date(year, 1, 1),
+      # Coming of Age Day
+      name == jholiday_names[2] ~
+        dplyr::if_else(
+          year >= 2000,
+          find_date_by_wday(year, 1, 2, 2),
+          lubridate::ymd(paste0(year, "0115"))
+        ),
+      # Foundation Day
+      name == jholiday_names[3] ~
+        dplyr::if_else(
+          year >= 1967,
+          lubridate::ymd(paste0(year, "0211")),
+          lubridate::as_date(NA_character_)
+        ),
+      # Vernal Equinox Day
+      name == jholiday_names[4] ~
+        lubridate::make_date(year, 3, day = shunbun_day(year)),
+      # Showa Day (2007-), Greenery Day (1989-2006), and The Emperor's Birthday (-1989)
+      (name == jholiday_names[5] & year >= 2007) |
+        (name == jholiday_names[6] & dplyr::between(year, 1989, 2006)) |
+        (name == jholiday_names[7] & year < 1989) ~
+        lubridate::make_date(year, 4, 29),
+      # Constitution Memorial Day
+      name == jholiday_names[8] ~
+        lubridate::make_date(year, 5, 3),
+      # Greenery Day (2007-), and Citizens' Holiday (1988-2006)
+      (name == jholiday_names[9] & year >= 2007) |
+        (name == jholiday_names[10] & dplyr::between(year, 1988, 2006)) ~
+        lubridate::make_date(year, 5, 4),
+      # Children's Day
+      name == jholiday_names[11] & year >= 1949 ~
+        lubridate::make_date(year, 5, 5),
+      # Marine Day
+      name == jholiday_names[12] & year == 2020 ~
+        lubridate::as_date("20200723"),
+      name == jholiday_names[12] & year >= 2003 & year != 2020 ~
+        find_date_by_wday(year, 7, 2, 3),
+      name == jholiday_names[12] & dplyr::between(year, 1996, 2002) ~
+        lubridate::make_date(year, 7, 20),
+      # Mountain Day
+      name == jholiday_names[13] & year == 2020 ~
+        lubridate::as_date("20200810"),
+      name == jholiday_names[13] & year >= 2016 & year != 2020 ~
+        lubridate::make_date(year, 8, 11),
+      # Respect for the Aged Day
+      name == jholiday_names[14] & dplyr::between(year, 1966, 2002) ~
+        lubridate::make_date(year, 9, 15),
+      name == jholiday_names[14] & year >= 2003 ~
+        find_date_by_wday(year, 9, 2, 3),
+      # Autumnal Equinox Day
+      name == jholiday_names[15] ~
+        lubridate::make_date(year, 9, day = shubun_day(year)),
+      # Sports Day
+      name == jholiday_names[17] & year == 2020 ~
+        lubridate::as_date("20200724"),
         name %in% jholiday_names[16:17] & year >= 2000 & year != 2020 ~
           find_date_by_wday(year, 10, 2, 2),
-        name %in% jholiday_names[16:17] & dplyr::between(year, 1966, 1999) ~
-          lubridate::make_date(year, 10, 10),
-        # Culture Day
-        name == jholiday_names[18] ~
-          lubridate::make_date(year, 11, 3),
-        # Labour Thanksgiving Day
-        name == jholiday_names[19] ~
-          lubridate::make_date(year, 11, 23),
-        # The Emperor's Birthday
-        name == jholiday_names[20] & dplyr::between(year, 1989, 2018) ~
-          lubridate::make_date(year, 12, 23),
-        name == jholiday_names[20] & year >= 2020 ~
-          lubridate::make_date(year, 2, 23)
-      )
-    unique(res)
+      name %in% jholiday_names[16:17] & dplyr::between(year, 1966, 1999) ~
+        lubridate::make_date(year, 10, 10),
+      # Culture Day
+      name == jholiday_names[18] ~
+        lubridate::make_date(year, 11, 3),
+      # Labour Thanksgiving Day
+      name == jholiday_names[19] ~
+        lubridate::make_date(year, 11, 23),
+      # The Emperor's Birthday
+      name == jholiday_names[20] & dplyr::between(year, 1989, 2018) ~
+        lubridate::make_date(year, 12, 23),
+      name == jholiday_names[20] & year >= 2020 ~
+        lubridate::make_date(year, 2, 23),
+      # default
+      TRUE ~ lubridate::as_date(NA_character_)
+    )
   }
 }
 
@@ -108,16 +108,9 @@ jholiday <- function(year, lang = "en") {
   jholiday_names <- jholiday_list[[lang]]
   if (are_all_current_law_yr(year)) {
     res <- jholiday_names %>%
-      purrr::map(~ as.numeric(jholiday_spec(year, name = .x, lang = lang))) %>%
+      purrr::map(~ jholiday_spec(year, name = .x, lang = lang)) %>%
       purrr::set_names(jholiday_names)
-    res <-
-      res[!duplicated(res)]
-    res %>%
-      unlist() %>%
-      purrr::discard(is.na) %>%
-      sort() %>%
-      as.list() %>%
-      purrr::map(lubridate::as_date)
+    res[!duplicated(res)]
   }
 }
 

--- a/R/jholiday.R
+++ b/R/jholiday.R
@@ -16,7 +16,7 @@
 #' jholiday(2020, "en")
 #' @export
 jholiday_spec <- function(year, name, lang = "en") {
-  if (is_current_law_yr(year)) {
+  if (are_all_current_law_yr(year)) {
     name <-
       jholiday_list %>%
       purrr::pluck(lang) %>%
@@ -100,7 +100,7 @@ jholiday_spec <- function(year, name, lang = "en") {
 #' @rdname jholiday
 #' @export
 jholiday <- function(year, lang = "en") {
-  if (is_current_law_yr(year)) {
+  if (are_all_current_law_yr(year)) {
     res <-
       jholiday_list %>%
       purrr::pluck(lang) %>%
@@ -118,9 +118,9 @@ jholiday <- function(year, lang = "en") {
   }
 }
 
-is_current_law_yr <- function(year) {
-  checked <- year >= 1948
-  if (checked == FALSE)
+are_all_current_law_yr <- function(years) {
+  checked <- all(years >= 1948)
+  if (!checked)
     rlang::warn("The year specified must be after the law was enacted in 1948")
   checked
 }

--- a/R/jholiday.R
+++ b/R/jholiday.R
@@ -174,16 +174,12 @@ is_jholiday <- function(date) {
     lubridate::as_date(date)
   yr <-
     unique(lubridate::year(date))
-  purrr::map2_lgl(date,
-                  yr,
-                  ~ dplyr::if_else(is.na(match(.x,
-                                               unique(
-                                                 c(jholiday_df$date,
-                                                   jholiday(.y, "en") %>%
-                                                     purrr::reduce(c))
-                                               ))),
-                                   FALSE,
-                                   TRUE))
+  jholidays <-
+    unique(c(
+      jholiday_df$date,            # Holidays from https://www8.cao.go.jp/chosei/shukujitsu/syukujitsu.csv
+      unlist(jholiday(yr, "en"))   # Calculated holidays
+    ))
+  date %in% jholidays
 }
 
 #' Find out the date of the specific month and weekday

--- a/R/jholiday.R
+++ b/R/jholiday.R
@@ -204,15 +204,19 @@ is_jholiday <- function(date) {
 find_date_by_wday <- function(year, month, wday, ordinal) {
   date_begin <-
     lubridate::make_date(year, month)
-  dom <-
-    date_begin + seq.int(0, lubridate::days_in_month(date_begin) - 1)
-  dom <-
-    lubridate::wday(dom) %>%
-    purrr::set_names(dom)
-  purrr::keep(dom,
-              ~ .x == as.character(wday))[ordinal] %>%
-    names() %>%
-    lubridate::as_date()
+  wday_of_date_begin <-
+    lubridate::wday(date_begin)
+  # First dates of the specified wday on each year-month
+  first_wday <-
+    date_begin + (wday - wday_of_date_begin) %% 7
+  # Add 1 ordinal = 1 week = 7 days
+  result <- first_wday + 7 * (ordinal - 1)
+  # If the calculated result is beyond the end of the month, fill it with NA
+  dplyr::if_else(
+    lubridate::month(result) == lubridate::month(date_begin),
+    result,
+    lubridate::as_date(NA_character_)
+  )
 }
 
 jholiday_list <-

--- a/R/jholiday.R
+++ b/R/jholiday.R
@@ -105,18 +105,16 @@ jholiday_spec <- function(year, name, lang = "en") {
 #' @rdname jholiday
 #' @export
 jholiday <- function(year, lang = "en") {
+  jholiday_names <- jholiday_list[[lang]]
   if (are_all_current_law_yr(year)) {
-    res <-
-      jholiday_list %>%
-      purrr::pluck(lang) %>%
+    res <- jholiday_names %>%
       purrr::map(~ as.numeric(jholiday_spec(year, name = .x, lang = lang))) %>%
-      purrr::set_names(jholiday_list %>%
-                         purrr::pluck(lang)) %>%
-      purrr::discard(is.na)
+      purrr::set_names(jholiday_names)
     res <-
       res[!duplicated(res)]
     res %>%
       unlist() %>%
+      purrr::discard(is.na) %>%
       sort() %>%
       as.list() %>%
       purrr::map(lubridate::as_date)
@@ -178,7 +176,7 @@ is_jholiday <- function(date) {
   date <-
     lubridate::as_date(date)
   yr <-
-    lubridate::year(date)
+    unique(lubridate::year(date))
   purrr::map2_lgl(date,
                   yr,
                   ~ dplyr::if_else(is.na(match(.x,

--- a/R/jholiday.R
+++ b/R/jholiday.R
@@ -16,82 +16,87 @@
 #' jholiday(2020, "en")
 #' @export
 jholiday_spec <- function(year, name, lang = "en") {
+  jholiday_names <- jholiday_list[[lang]]
+
   if (are_all_current_law_yr(year)) {
-    name <-
-      jholiday_list %>%
-      purrr::pluck(lang) %>%
-      purrr::keep(~ .x == name)
+    if (!name %in% jholiday_names) {
+      rlang::abort(glue::glue("No such holiday: {name}"))
+    }
     res <-
       dplyr::case_when(
-        name %in% c(jholiday_list %>%
-                      purrr::map_chr(1)) ~ lubridate::make_date(year, 1, 1),
-        name %in% c(jholiday_list %>%
-                      purrr::map_chr(2)) ~ dplyr::if_else(
-                        year >= 2000,
-                        find_date_by_wday(year, 1, 2, 2),
-                        lubridate::ymd(paste0(year, "0115"))),
-        name %in% c(jholiday_list %>%
-                      purrr::map_chr(3)) ~ dplyr::if_else(
-                        year >= 1967,
-                        lubridate::ymd(paste0(year, "0211")),
-                        lubridate::as_date(NA_character_)),
-        name %in% c(jholiday_list %>%
-                      purrr::map_chr(4)) ~ lubridate::make_date(year, 3, day = shunbun_day(year)),
-        name %in% c(jholiday_list %>%
-                      purrr::map(`[[`, 5) %>%
-                      purrr::flatten_chr()) & year >= 2007 ~ lubridate::make_date(year, 4, 29),
-        name %in% c(jholiday_list %>%
-                      purrr::map(`[[`, 6) %>%
-                      purrr::flatten_chr()) & dplyr::between(year, 1989, 2006) ~ lubridate::make_date(year, 4, 29),
-        name %in% c(jholiday_list %>%
-                      purrr::map(`[[`, 7) %>%
-                      purrr::flatten_chr()) & year < 1989 ~ lubridate::make_date(year, 4, 29),
-        name %in% c(jholiday_list %>%
-                      purrr::map_chr(8)) ~ lubridate::make_date(year, 5, 3),
-        name %in% c(jholiday_list %>%
-                      purrr::map(`[[`, 9) %>%
-                      purrr::flatten_chr()) & year >= 2007 ~ lubridate::make_date(year, 5, 4),
-        name %in% c(jholiday_list %>%
-                      purrr::map(`[[`, 10) %>%
-                      purrr::flatten_chr()) & dplyr::between(year, 1988, 2006) ~ lubridate::make_date(year, 5, 4),
-        name %in% c(jholiday_list %>%
-                      purrr::map_chr(11)) & year >= 1949 ~ lubridate::make_date(year, 5, 5),
-        name %in% c(jholiday_list %>%
-                      purrr::map_chr(12)) & year == 2020 ~ lubridate::as_date("20200723"),
-        name %in% c(jholiday_list %>%
-                      purrr::map_chr(12)) & year >= 2003 & year != 2020 ~ find_date_by_wday(year, 7, 2, 3),
-        name %in% c(jholiday_list %>%
-                      purrr::map_chr(12)) & dplyr::between(year, 1996, 2002) ~ lubridate::make_date(year, 7, 20),
-        name %in% c(jholiday_list %>%
-                      purrr::map_chr(13)) & year == 2020 ~ lubridate::as_date("20200810"),
-        name %in% c(jholiday_list %>%
-                      purrr::map_chr(13)) & year >= 2016 & year != 2020 ~ lubridate::make_date(year, 8, 11),
-        name %in% c(jholiday_list %>%
-                      purrr::map_chr(14)) & dplyr::between(year, 1966, 2002) ~ lubridate::make_date(year, 9, 15),
-        name %in% c(jholiday_list %>%
-                      purrr::map_chr(14)) & year >= 2003 ~ find_date_by_wday(year, 9, 2, 3),
-        name %in% c(jholiday_list %>%
-                      purrr::map_chr(15)) ~ lubridate::make_date(year, 9, day = shubun_day(year)),
-        name %in% c(jholiday_list %>%
-                      purrr::map_chr(17)) & year == 2020 ~ lubridate::as_date("20200724"),
-        name %in% c(jholiday_list %>%
-                      purrr::map(`[`, c(16, 17)) %>%
-                      unlist() %>%
-                      unique()) & year >= 2000 & year != 2020 ~ find_date_by_wday(year, 10, 2, 2),
-        name %in% c(jholiday_list %>%
-                      purrr::map(`[`, c(16, 17)) %>%
-                      unlist() %>%
-                      unique()) &  dplyr::between(year, 1966, 1999) ~ lubridate::make_date(year, 10, 10),
-        name %in% c(jholiday_list %>%
-                      purrr::map_chr(18)) ~ lubridate::make_date(year, 11, 3),
-        name %in% c(jholiday_list %>%
-                      purrr::map_chr(19)) ~ lubridate::make_date(year, 11, 23),
-        name %in% c(jholiday_list %>%
-                      purrr::map(`[[`, 20) %>%
-                      purrr::flatten_chr()) & dplyr::between(year, 1989, 2018) ~ lubridate::make_date(year, 12, 23),
-        name %in% c(jholiday_list %>%
-                      purrr::map(`[[`, 20) %>%
-                      purrr::flatten_chr()) & year >= 2020 ~ lubridate::make_date(year, 2, 23)
+        # New Year's Day
+        name == jholiday_names[1] ~
+          lubridate::make_date(year, 1, 1),
+        # Coming of Age Day
+        name == jholiday_names[2] ~
+          dplyr::if_else(
+            year >= 2000,
+            find_date_by_wday(year, 1, 2, 2),
+            lubridate::ymd(paste0(year, "0115"))
+          ),
+        # Foundation Day
+        name == jholiday_names[3] ~
+          dplyr::if_else(
+            year >= 1967,
+            lubridate::ymd(paste0(year, "0211")),
+            lubridate::as_date(NA_character_)
+          ),
+        # Vernal Equinox Day
+        name == jholiday_names[4] ~
+          lubridate::make_date(year, 3, day = shunbun_day(year)),
+        # Showa Day (2007-), Greenery Day (1989-2006), and The Emperor's Birthday (-1989)
+        (name == jholiday_names[5] & year >= 2007) |
+          (name == jholiday_names[6] & dplyr::between(year, 1989, 2006)) |
+          (name == jholiday_names[7] & year < 1989) ~
+            lubridate::make_date(year, 4, 29),
+        # Constitution Memorial Day
+        name == jholiday_names[8] ~
+          lubridate::make_date(year, 5, 3),
+        # Greenery Day (2007-), and Citizens' Holiday (1988-2006)
+        (name == jholiday_names[9] & year >= 2007) |
+          (name == jholiday_names[10] & dplyr::between(year, 1988, 2006)) ~
+          lubridate::make_date(year, 5, 4),
+        # Children's Day
+        name == jholiday_names[11] & year >= 1949 ~
+          lubridate::make_date(year, 5, 5),
+        # Marine Day
+        name == jholiday_names[12] & year == 2020 ~
+          lubridate::as_date("20200723"),
+        name == jholiday_names[12] & year >= 2003 & year != 2020 ~
+          find_date_by_wday(year, 7, 2, 3),
+        name == jholiday_names[12] & dplyr::between(year, 1996, 2002) ~
+          lubridate::make_date(year, 7, 20),
+        # Mountain Day
+        name == jholiday_names[13] & year == 2020 ~
+          lubridate::as_date("20200810"),
+        name == jholiday_names[13] & year >= 2016 & year != 2020 ~
+          lubridate::make_date(year, 8, 11),
+        # Respect for the Aged Day
+        name == jholiday_names[14] & dplyr::between(year, 1966, 2002) ~
+          lubridate::make_date(year, 9, 15),
+        name == jholiday_names[14] & year >= 2003 ~
+          find_date_by_wday(year, 9, 2, 3),
+        # Autumnal Equinox Day
+        name == jholiday_names[15] ~
+          lubridate::make_date(year, 9, day = shubun_day(year)),
+        # Sports Day
+        name == jholiday_names[17] & year == 2020 ~
+          lubridate::as_date("20200724"),
+        name %in% jholiday_names[16:17] & year >= 2000 & year != 2020 ~
+          find_date_by_wday(year, 10, 2, 2),
+        name %in% jholiday_names[16:17] & dplyr::between(year, 1966, 1999) ~
+          lubridate::make_date(year, 10, 10),
+        # Culture Day
+        name == jholiday_names[18] ~
+          lubridate::make_date(year, 11, 3),
+        # Labour Thanksgiving Day
+        name == jholiday_names[19] ~
+          lubridate::make_date(year, 11, 23),
+        # The Emperor's Birthday
+        name == jholiday_names[20] & dplyr::between(year, 1989, 2018) ~
+          lubridate::make_date(year, 12, 23),
+        name == jholiday_names[20] & year >= 2020 ~
+          lubridate::make_date(year, 2, 23)
       )
     unique(res)
   }

--- a/R/jholiday.R
+++ b/R/jholiday.R
@@ -107,10 +107,14 @@ jholiday_spec <- function(year, name, lang = "en") {
 jholiday <- function(year, lang = "en") {
   jholiday_names <- jholiday_list[[lang]]
   if (are_all_current_law_yr(year)) {
-    res <- jholiday_names %>%
+    res <-
+      jholiday_names %>%
       purrr::map(~ jholiday_spec(year, name = .x, lang = lang)) %>%
       purrr::set_names(jholiday_names)
-    res[!duplicated(res)]
+    res <-
+      res[!duplicated(res)]
+    res %>%
+      purrr::discard(~ all(is.na(.)))
   }
 }
 

--- a/R/jholiday.R
+++ b/R/jholiday.R
@@ -20,7 +20,7 @@ jholiday_spec <- function(year, name, lang = "en") {
 
   if (are_all_current_law_yr(year)) {
     if (!name %in% jholiday_names) {
-      rlang::abort(glue::glue("No such holiday: {name}"))
+      rlang::abort(sprintf("No such holiday: %s", name))
     }
     res <-
       dplyr::case_when(

--- a/tests/testthat/test-jholiday.R
+++ b/tests/testthat/test-jholiday.R
@@ -35,6 +35,10 @@ test_that("Specific year's holiday", {
     length(jholiday(2020, "en")),
     16L
   )
+  expect_equal(
+    length(jholiday(2019:2020, "en")),
+    31L
+  )
 })
 
 test_that("Another approaches", {

--- a/tests/testthat/test-jholiday.R
+++ b/tests/testthat/test-jholiday.R
@@ -232,6 +232,16 @@ test_that("Is jholiday works", {
   expect_true(
     is_jholiday(lubridate::ymd("1989-02-11"))
   )
+  # multiple dates
+  expect_equal(
+    is_jholiday(as.Date("2020-01-01") + 0:2),
+    c(TRUE, FALSE, FALSE)
+  )
+  # multiple dates in multiple years
+  expect_equal(
+    is_jholiday(as.Date(c("2019-01-01", "2020-01-01"))),
+    c(TRUE, TRUE)
+  )
 })
 
 test_that("Utils", {

--- a/tests/testthat/test-jholiday.R
+++ b/tests/testthat/test-jholiday.R
@@ -236,13 +236,23 @@ test_that("Is jholiday works", {
 
 test_that("Utils", {
   expect_true(
-    is_current_law_yr(1948)
+    are_all_current_law_yr(1948)
   )
   expect_warning(
     expect_false(
-    is_current_law_yr(1947),
-    "The year specified must be after the law was enacted in 1948"
-  ))
+      are_all_current_law_yr(1947),
+      "The year specified must be after the law was enacted in 1948"
+    )
+  )
+  expect_true(
+    are_all_current_law_yr(1948:1950)
+  )
+  expect_warning(
+    expect_false(
+      are_all_current_law_yr(1947:1949),
+      "The year specified must be after the law was enacted in 1948"
+    )
+  )
   expect_equal(
     find_date_by_wday(2020, 1, 2, 2),
     as.Date("2020-01-13")

--- a/tests/testthat/test-jholiday.R
+++ b/tests/testthat/test-jholiday.R
@@ -266,6 +266,10 @@ test_that("Utils", {
     as.Date(NA_character_)
   )
   expect_equal(
+    find_date_by_wday(2018:2020, 1, 2, 2),
+    as.Date(c("2018-01-08", "2019-01-14", "2020-01-13"))
+  )
+  expect_equal(
     shunbun_day(1966),
     21
   )

--- a/tests/testthat/test-jholiday.R
+++ b/tests/testthat/test-jholiday.R
@@ -35,9 +35,14 @@ test_that("Specific year's holiday", {
     length(jholiday(2020, "en")),
     16L
   )
+  res <- jholiday(2019:2020, "en")
   expect_equal(
-    length(jholiday(2019:2020, "en")),
-    31L
+    length(res),
+    16L
+  )
+  expect_equal(
+    unique(purrr::map_int(res, length)),
+    2L
   )
 })
 


### PR DESCRIPTION
Related: #15

以下の関数に複数の`year`を渡せるようになります。

* `find_date_by_wday()`
* `jholiday_spec()`
* `jholiday()`
* `is_jholiday()`（これはすでに https://github.com/uribo/zipangu/commit/3c01ca58a4cf7676b448ed0983d8819aedf474f4 で対応済みだけど、速くなったはず）

### 使用例

``` r
library(zipangu)

find_date_by_wday(2011:2020, 1, 2, 3)
#>  [1] "2011-01-17" "2012-01-16" "2013-01-21" "2014-01-20" "2015-01-19"
#>  [6] "2016-01-18" "2017-01-16" "2018-01-15" "2019-01-21" "2020-01-20"

jholiday_spec(2011:2020, "Vernal Equinox Day")
#>  [1] "2011-03-21" "2012-03-20" "2013-03-20" "2014-03-21" "2015-03-21"
#>  [6] "2016-03-20" "2017-03-20" "2018-03-21" "2019-03-21" "2020-03-20"

jholiday(2011:2020)
#> $`New Year's Day`
#>  [1] "2011-01-01" "2012-01-01" "2013-01-01" "2014-01-01" "2015-01-01"
#>  [6] "2016-01-01" "2017-01-01" "2018-01-01" "2019-01-01" "2020-01-01"
#> 
#> $`Coming of Age Day`
#>  [1] "2011-01-10" "2012-01-09" "2013-01-14" "2014-01-13" "2015-01-12"
#>  [6] "2016-01-11" "2017-01-09" "2018-01-08" "2019-01-14" "2020-01-13"
#> 
#> $`Foundation Day`
#>  [1] "2011-02-11" "2012-02-11" "2013-02-11" "2014-02-11" "2015-02-11"
#>  [6] "2016-02-11" "2017-02-11" "2018-02-11" "2019-02-11" "2020-02-11"
#> 
#> $`Vernal Equinox Day`
#>  [1] "2011-03-21" "2012-03-20" "2013-03-20" "2014-03-21" "2015-03-21"
#>  [6] "2016-03-20" "2017-03-20" "2018-03-21" "2019-03-21" "2020-03-20"
#> 
#> $`Showa Day`
#>  [1] "2011-04-29" "2012-04-29" "2013-04-29" "2014-04-29" "2015-04-29"
#>  [6] "2016-04-29" "2017-04-29" "2018-04-29" "2019-04-29" "2020-04-29"
#> 
#> $`Greenery Day`
#>  [1] "2011-05-04" "2012-05-04" "2013-05-04" "2014-05-04" "2015-05-04"
#>  [6] "2016-05-04" "2017-05-04" "2018-05-04" "2019-05-04" "2020-05-04"
#> 
#> $`The Emperor's Birthday`
#>  [1] "2011-12-23" "2012-12-23" "2013-12-23" "2014-12-23" "2015-12-23"
#>  [6] "2016-12-23" "2017-12-23" "2018-12-23" NA           "2020-02-23"
#> 
#> $`Constitution Memorial Day`
#>  [1] "2011-05-03" "2012-05-03" "2013-05-03" "2014-05-03" "2015-05-03"
#>  [6] "2016-05-03" "2017-05-03" "2018-05-03" "2019-05-03" "2020-05-03"
#> 
#> $`Children's Day`
#>  [1] "2011-05-05" "2012-05-05" "2013-05-05" "2014-05-05" "2015-05-05"
#>  [6] "2016-05-05" "2017-05-05" "2018-05-05" "2019-05-05" "2020-05-05"
#> 
#> $`Marine Day`
#>  [1] "2011-07-18" "2012-07-16" "2013-07-15" "2014-07-21" "2015-07-20"
#>  [6] "2016-07-18" "2017-07-17" "2018-07-16" "2019-07-15" "2020-07-23"
#> 
#> $`Mountain Day`
#>  [1] NA           NA           NA           NA           NA          
#>  [6] "2016-08-11" "2017-08-11" "2018-08-11" "2019-08-11" "2020-08-10"
#> 
#> $`Respect for the Aged Day`
#>  [1] "2011-09-19" "2012-09-17" "2013-09-16" "2014-09-15" "2015-09-21"
#>  [6] "2016-09-19" "2017-09-18" "2018-09-17" "2019-09-16" "2020-09-21"
#> 
#> $`Autumnal Equinox Day`
#>  [1] "2011-09-23" "2012-09-22" "2013-09-23" "2014-09-23" "2015-09-23"
#>  [6] "2016-09-22" "2017-09-23" "2018-09-23" "2019-09-23" "2020-09-22"
#> 
#> $`Sports Day`
#>  [1] "2011-10-10" "2012-10-08" "2013-10-14" "2014-10-13" "2015-10-12"
#>  [6] "2016-10-10" "2017-10-09" "2018-10-08" "2019-10-14" "2020-07-24"
#> 
#> $`Culture Day`
#>  [1] "2011-11-03" "2012-11-03" "2013-11-03" "2014-11-03" "2015-11-03"
#>  [6] "2016-11-03" "2017-11-03" "2018-11-03" "2019-11-03" "2020-11-03"
#> 
#> $`Labour Thanksgiving Day`
#>  [1] "2011-11-23" "2012-11-23" "2013-11-23" "2014-11-23" "2015-11-23"
#>  [6] "2016-11-23" "2017-11-23" "2018-11-23" "2019-11-23" "2020-11-23"
```

<sup>Created on 2020-04-05 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
