### PR TITLE
Unify the output of `kansuji2arabic_all` with the other output

### DIFF
--- a/R/kansuji.R
+++ b/R/kansuji.R
@@ -61,11 +61,14 @@ kansuji2arabic <- function(str, convert = TRUE, .under = Inf) {
 #' @rdname kansuji
 #' @export
 kansuji2arabic_all <- function(str, ...) {
-  stringr::str_split(str,
-                     pattern = stringr::boundary("character")) %>%
-    purrr::map(kansuji2arabic, ...) %>%
-    purrr::reduce(c) %>%
-    paste(collapse = "")
+  purrr::map(str, function(str, ...){
+    stringr::str_split(str,
+                       pattern = stringr::boundary("character")) %>%
+      purrr::map(kansuji2arabic, ...) %>%
+      purrr::reduce(c) %>%
+      paste(collapse = "")
+  }) %>%
+    unlist()
 }
 
 #'

--- a/R/kansuji.R
+++ b/R/kansuji.R
@@ -61,14 +61,13 @@ kansuji2arabic <- function(str, convert = TRUE, .under = Inf) {
 #' @rdname kansuji
 #' @export
 kansuji2arabic_all <- function(str, ...) {
-  purrr::map(str, function(str, ...){
+  purrr::map_chr(str, function(str, ...){
     stringr::str_split(str,
                        pattern = stringr::boundary("character")) %>%
       purrr::map(kansuji2arabic, ...) %>%
       purrr::reduce(c) %>%
       paste(collapse = "")
-  }, ...) %>%
-    unlist()
+  }, ...)
 }
 
 #'

--- a/R/kansuji.R
+++ b/R/kansuji.R
@@ -67,7 +67,7 @@ kansuji2arabic_all <- function(str, ...) {
       purrr::map(kansuji2arabic, ...) %>%
       purrr::reduce(c) %>%
       paste(collapse = "")
-  }) %>%
+  }, ...) %>%
     unlist()
 }
 


### PR DESCRIPTION
既存の`kansuji2arabic_all`は複数の文字列を与えたときに、結果出力時に文字列が結合されてしまいます。

```r
zipangu::kansuji2arabic_all(c("一", "二", "三"))
[1] "123"
> zipangu::kansuji2arabic_all(c("一歳", "二年", "三月"))
[1] "1歳2年3月"
```

`kansuji2arabic`では
```r
zipangu::kansuji2arabic(c("一", "二", "三"))
[1] "1" "2" "3"
```
となるので、特別な意図がないのであれば同様の挙動をしてほしいと思っています。

もとのコードで行っている処理を最大限維持するのであれば、`purrr:map`で処理するのが妥当かと考えており、そのコードを提案します。

これで
```r
zipangu::kansuji2arabic_all(c("一", "二", "三"))
[1] "1" "2" "3"
zipangu::kansuji2arabic_all(c("一歳", "二年", "三月"))
[1] "1歳" "2年" "3月"
zipangu::kansuji2arabic_all(c("一歳", "二年", "三月"), .under = 2)
[1] "1歳"  "二年" "三月"
```
となるはずです。

些末な提案ですみませんが、ご検討ください。