### PR TITLE
The output of `kansuji2arabic_num` is unified to a string type.

### DIFF
--- a/R/kansuji.R
+++ b/R/kansuji.R
@@ -133,7 +133,6 @@ kansuji2arabic_num_single <- function(str, consecutive = c("convert", "non"), ..
   if(!any(n >= 10000)){
     if(length(n) == 1){
       res <- n
-      return(res)
     }else{
       res <- NULL
       for(i in 1:length(n)){
@@ -148,11 +147,9 @@ kansuji2arabic_num_single <- function(str, consecutive = c("convert", "non"), ..
       }
     }
     res <- sum(stats::na.omit(res))
-    return(res)
   }else{
     if(length(n) == 1){
       res <- n
-      return(res)
     }else{
       ans <- NULL
       l <- 1
@@ -187,10 +184,10 @@ kansuji2arabic_num_single <- function(str, consecutive = c("convert", "non"), ..
         l <- digits_location[k] + 1
         k <- k + 1
       }
-      ans <- sum(stats::na.omit(ans))
-      return(ans)
+      res <- sum(stats::na.omit(ans))
     }
   }
+  return(as.character(res))
 }
 
 #' @rdname kansuji

--- a/tests/testthat/test-kanji.R
+++ b/tests/testthat/test-kanji.R
@@ -28,11 +28,11 @@ test_that("convert kansuji to arabic works", {
   )
   expect_equal(
     kansuji2arabic_num("\u4e00\u5104\u4e8c\u5343\u4e09\u767e\u56db\u5341\u4e94\u4e07\u516d\u5343\u4e03\u767e\u516b\u5341\u4e5d"),
-    123456789
+    "123456789"
   )
   expect_equal(
     kansuji2arabic_num("\u4e00\u5104\u4e8c\u4e09\u56db\u4e94\u4e07\u516d\u4e03\u516b\u4e5d"),
-    123456789
+    "123456789"
   )
   expect_equal(
     kansuji2arabic_str("\u91d1\u4e00\u5104\u4e8c\u5343\u4e09\u767e\u56db\u5341\u4e94\u4e07\u516d\u5343\u4e03\u767e\u516b\u5341\u4e5d\u5186"),


### PR DESCRIPTION
自分で提案したコードの不備で大変申し訳ないのですが次の問題があり、その解決策について提案します。

`kansuji2arabic_num()`の結果について`1234`という結果が得られる、`千二百三十四`は数値型でリターンしていますが、`一二三四`については文字列型になってしまいました。

一つの関数で入力されるデータの形に依存してはいますが、特に入力者側で引数を指定するなどの意図をしていないにも関わらず結果の型が変わってくるのはあまり良くないと思いました。

この件について、数値型の文字列型のいずれがいいのかということについて考えると、

* `kansuji2arabic`以外の関数が文字列型での結果のみをサポートしている。
* `〇一二`など`0`から始まる数をこの関数でも文字列型で`"012"`と返すことを想定している。これを数値型とすると`12`となってしまうので、例えば郵便番号などの処理において不適切になってしまうのではないか。

という2点を考慮し、文字列型での結果の統一が妥当なのではないかと考えました。

そこで、`kansuji2arabic_num()`について結果が文字列型で統一されるように修正しました。それに合わせてテストも修正しました。

度々のPull Requestになってしまいすみません。
お手すきのときに検討していただければと思います。