### PR TITLE
Improve is_jyear() character matching

### DIFF
--- a/R/convert-jyear.R
+++ b/R/convert-jyear.R
@@ -85,14 +85,35 @@ is_jyear <- function(jyear) {
   pattern <- paste0(
     "^(",
     paste(jyear_sets %>%
+            purrr::map(~ .x[c("kanji", "roman")]) %>%
             purrr::flatten() %>%
-            purrr::keep(is.character) %>%
             purrr::as_vector(),
           collapse = "|"),
-    ")"
-  )
-
-  stringr::str_detect(jyear_initial_tolower(jyear), pattern)
+    ")")
+  res <-
+    stringr::str_detect(jyear_initial_tolower(jyear),
+                        pattern)
+  res %>%
+    purrr::map2_lgl(
+      .y = jyear,
+      function(.x, .y) {
+        if (is.na(.x)) {
+          .x
+        } else if (.x == FALSE) {
+          pattern <- paste0(
+            "^(",
+            paste(jyear_sets %>%
+                    purrr::map(~ .x[c("kanji_capital", "roman_capital")]) %>%
+                    purrr::flatten(),
+                  collapse = "|"),
+            ")([0-9]|[\u3007\u4e00\u4e8c\u4e09\u56db\u4e94\u516d\u4e03\u516b\u4e5d\u5341])")
+          stringr::str_detect(jyear_initial_tolower(.y),
+                              pattern)
+        } else {
+          TRUE
+        }
+      }
+    )
 }
 
 convert_jyear_roman <- function(x) {


### PR DESCRIPTION
## Summary

元号の漢字表記とローマ字表記とのマッチ、元号の頭文字のマッチを分割。頭文字の場合、年を表す数値が連続して与えられていない場合には `FALSE` を返却するように。

``` r
library(zipangu)
zipangu:::is_jyear(c("令和元年", "Reiwa2", 
                     # 存在しない元号
                     "reima3"))
#> [1]  TRUE  TRUE FALSE
convert_jyear("Reima3")
#> Warning: Unsupported Japanese imperial year.
#> Please include the year after 1868 or the year used since then, Meiji, Taisho, Showa, Heisei and Reiwa.
#> [1] NA
convert_jyear("平30")
#> [1] 2018
convert_jyear("平ら")
#> Warning: Unsupported Japanese imperial year.
#> Please include the year after 1868 or the year used since then, Meiji, Taisho, Showa, Heisei and Reiwa.
#> [1] NA
```

<sup>Created on 2021-02-01 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>

## Related issues

Close #22
