### PR TITLE
Conversion by splitting date elements

### DIFF
--- a/R/convert-jyear.R
+++ b/R/convert-jyear.R
@@ -91,6 +91,28 @@ jyear_initial_tolower <- function(jyear) {
   jyear
 }
 
+split_ymd_elements <- function(x) {
+  x %>%
+    purrr::map(
+      function(.x) {
+        if (is.na(.x)) {
+          NA_real_
+        } else {
+          .x %>%
+            stringi::stri_trans_general(id = "nfkc") %>%
+            stringr::str_split("(\u5e74|\u6708|\u65e5)|(\\.)|(\\-)|(\\/)",
+                               simplify = TRUE) %>%
+            purrr::keep(~ nchar(.) > 0) %>%
+            purrr::modify_at(1,
+                             ~ convert_jyear(.x)) %>%
+            purrr::map(as.integer) %>%
+            purrr::set_names(c("year", "month", "day"))
+        }
+      }
+      ) %>%
+    purrr::flatten()
+}
+
 is_jyear <- function(jyear) {
   pattern <- paste0(
     "^(",

--- a/R/convert-jyear.R
+++ b/R/convert-jyear.R
@@ -68,15 +68,17 @@ convert_jyear <- function(jyear) {
 #' ```
 #'
 #' ```{r}
+#' convert_jdate("R3/2/27")
 #' convert_jdate("\u4ee4\u548c2\u5e747\u67086\u65e5")
 #' ```
 #' @export
 convert_jdate <- function(date) {
   date %>%
-    stringi::stri_trans_nfkc() %>%
-    stringr::str_replace(".*(?=\u5e74)",
-                         convert_jyear) %>%
-    lubridate::ymd()
+    purrr::map(
+      ~ rlang::exec(lubridate::make_date,
+                    !!!split_ymd_elements(.x))
+    ) %>%
+    purrr::reduce(c)
 }
 
 jyear_initial_tolower <- function(jyear) {

--- a/man/convert_jdate.Rd
+++ b/man/convert_jdate.Rd
@@ -13,7 +13,9 @@ convert_jdate(date)
 \Sexpr[results=rd, stage=render]{lifecycle::badge("maturing")}
 }
 \section{Examples}{
-\if{html}{\out{<div class="r">}}\preformatted{convert_jdate("\\u4ee4\\u548c2\\u5e747\\u67086\\u65e5")
+\if{html}{\out{<div class="r">}}\preformatted{convert_jdate("R3/2/27")
+}\if{html}{\out{</div>}}\preformatted{## [1] "2021-02-27"
+}\if{html}{\out{<div class="r">}}\preformatted{convert_jdate("\\u4ee4\\u548c2\\u5e747\\u67086\\u65e5")
 }\if{html}{\out{</div>}}\preformatted{## [1] "2020-07-06"
 }
 }

--- a/tests/testthat/test-jyear.R
+++ b/tests/testthat/test-jyear.R
@@ -34,7 +34,14 @@ test_that("convert japanese date format", {
     convert_jdate("\u4ee4\u548c2\u5e747\u67086\u65e5"),
     as.Date("2020-07-06")
   )
-
+  expect_equal(
+    convert_jdate("H20.4.1"),
+    convert_jdate("\u5e73\u621020\u5e744\u67081\u65e5")
+  )
+  expect_equal(
+    convert_jdate("R2/12/1"),
+    convert_jdate("R2-12-01")
+  )
   expect_equal(
     convert_jdate(c("\u5e73\u621030\u5e741\u67081\u65e5", "\u5e73\u621030\u5e742\u67081\u65e5", NA)),
     as.Date(c("2018-01-01", "2018-02-01", NA))


### PR DESCRIPTION
## Summary

#34 のための `convert_jdate()` の修正。
日付の文字列を年月日の要素に分割する関数 `split_ymd_elements()` を追加 (exportせず)。これにより、`.`や`-`などが年月日の区切りに使われる文字列が与えられた時にも変換が正常に行えるようにした。

```r
convert_jdate("H20/4/1")
#> [1] "2008-04-01"
convert_jdate("平成20.4.1")
#> [1] "2008-04-01"
convert_jdate("平20.4.1")
#> [1] "2008-04-01"
```

## Related issues

Close #34 