### PR TITLE
jholiday()の結果の並び替え

### DIFF
--- a/R/jholiday.R
+++ b/R/jholiday.R
@@ -177,6 +177,13 @@ jholiday <- function(year, lang = "en") {
       purrr::imap(function(x, y) {
         sort(x)
       })
+    res <-
+      res[res %>%
+          purrr::map(1) %>%
+          purrr::flatten_dbl() %>%
+          purrr::set_names(names(res)) %>%
+          sort() %>%
+          names()]
     res
   }
 }

--- a/man/jholiday.Rd
+++ b/man/jholiday.Rd
@@ -43,26 +43,29 @@ List of a specific year holidays\if{html}{\out{<div class="sourceCode r">}}\pref
 ## $`Foundation Day`
 ## [1] "2021-02-11"
 ## 
+## $`The Emperor's Birthday`
+## [1] "2021-02-23"
+## 
 ## $`Vernal Equinox Day`
 ## [1] "2021-03-20"
 ## 
 ## $`Showa Day`
 ## [1] "2021-04-29"
 ## 
-## $`Greenery Day`
-## [1] "2021-05-04"
-## 
-## $`The Emperor's Birthday`
-## [1] "2021-02-23"
-## 
 ## $`Constitution Memorial Day`
 ## [1] "2021-05-03"
+## 
+## $`Greenery Day`
+## [1] "2021-05-04"
 ## 
 ## $`Children's Day`
 ## [1] "2021-05-05"
 ## 
 ## $`Marine Day`
 ## [1] "2021-07-22"
+## 
+## $`Sports Day`
+## [1] "2021-07-23"
 ## 
 ## $`Mountain Day`
 ## [1] "2021-08-08"
@@ -72,9 +75,6 @@ List of a specific year holidays\if{html}{\out{<div class="sourceCode r">}}\pref
 ## 
 ## $`Autumnal Equinox Day`
 ## [1] "2021-09-23"
-## 
-## $`Sports Day`
-## [1] "2021-07-23"
 ## 
 ## $`Culture Day`
 ## [1] "2021-11-03"

--- a/tests/testthat/test-jholiday.R
+++ b/tests/testthat/test-jholiday.R
@@ -48,6 +48,14 @@ test_that("Specific year's holiday", {
     unique(purrr::map_int(res, length)),
     2L
   )
+  expect_equal(
+    names(jholiday(2021, lang = "en")),
+    c("New Year's Day", "Coming of Age Day", "Foundation Day", "The Emperor's Birthday",
+      "Vernal Equinox Day", "Showa Day", "Constitution Memorial Day",
+      "Greenery Day", "Children's Day", "Marine Day", "Sports Day",
+      "Mountain Day", "Respect for the Aged Day", "Autumnal Equinox Day",
+      "Culture Day", "Labour Thanksgiving Day")
+  )
   expect_error(
     jholiday_spec(2019:2020, c("Coming of Age Day",
                                "Foundation Day",


### PR DESCRIPTION
## Summary

開発版で生じている問題

``` r
# CRAN version
withr::with_package("zipangu", {
  names(jholiday(2021, lang = "jp"))
})
#>  [1] "元日"         "成人の日"     "建国記念の日" "天皇誕生日"   "春分の日"    
#>  [6] "昭和の日"     "憲法記念日"   "みどりの日"   "こどもの日"   "海の日"      
#> [11] "スポーツの日" "山の日"       "敬老の日"     "秋分の日"     "文化の日"    
#> [16] "勤労感謝の日"

# Development version
withr::with_temp_libpaths({
  remotes::install_github("uribo/zipangu")
  names(zipangu::jholiday(2021, lang = "jp"))
})
#> Using github PAT from envvar GITHUB_PAT
#> Downloading GitHub repo uribo/zipangu@HEAD
#> 
#> * checking for file ‘/private/var/folders/7f/g31qsmpx03j5m9054l89cb200000gn/T/Rtmp0VZTMu/remotes170d45a04a5a0/uribo-zipangu-b60a7a4/DESCRIPTION’ ... OK
#> * preparing ‘zipangu’:
#> * checking DESCRIPTION meta-information ... OK
#> * installing the package to process help pages
#> * checking for LF line-endings in source and make files and shell scripts
#> * checking for empty or unneeded directories
#> * building ‘zipangu_0.2.3.9000.tar.gz’
#>  パッケージを '/private/var/folders/7f/g31qsmpx03j5m9054l89cb200000gn/T/Rtmp0VZTMu/temp_libpath170d43d7d5d32' 中にインストールします 
#>  ('lib' が指定されていないため)
#>  [1] "元日"         "成人の日"     "建国記念の日" "春分の日"     "昭和の日"    
#>  [6] "みどりの日"   "天皇誕生日"   "憲法記念日"   "こどもの日"   "海の日"      
#> [11] "山の日"       "敬老の日"     "秋分の日"     "スポーツの日" "文化の日"    
#> [16] "勤労感謝の日"
```


<sup>Created on 2022-03-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

`天皇誕生日`は2021-02-23なので本来は`建国記念日`の後にくるが開発版では`みどりの日`の後となっています。これを修正するための処理を加えました。

``` r
withr::with_temp_libpaths({
  remotes::install_github("uribo/zipangu@feature/jholiday_sort")
  names(zipangu::jholiday(2021, lang = "jp"))
})
#> Using github PAT from envvar GITHUB_PAT
#> Downloading GitHub repo uribo/zipangu@feature/jholiday_sort
#> 
#> * checking for file ‘/private/var/folders/_k/8syww8ls39n5dkvwy1yk8dgc0000gn/T/RtmpxMz5a5/remotescc76f45029d/uribo-zipangu-f940d1c/DESCRIPTION’ ... OK
#> * preparing ‘zipangu’:
#> * checking DESCRIPTION meta-information ... OK
#> * installing the package to process help pages
#> * checking for LF line-endings in source and make files and shell scripts
#> * checking for empty or unneeded directories
#> * building ‘zipangu_0.2.3.9000.tar.gz’
#> Installing package into '/private/var/folders/_k/8syww8ls39n5dkvwy1yk8dgc0000gn/T/RtmpxMz5a5/temp_libpathcc728da460f'
#> (as 'lib' is unspecified)
#>  [1] "元日"         "成人の日"     "建国記念の日" "天皇誕生日"   "春分の日"    
#>  [6] "昭和の日"     "憲法記念日"   "みどりの日"   "こどもの日"   "海の日"      
#> [11] "スポーツの日" "山の日"       "敬老の日"     "秋分の日"     "文化の日"    
#> [16] "勤労感謝の日"
```

<sup>Created on 2022-03-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

## Related issues

なし