### PR TITLE
Proposal to support `arabic2kansuji_all()` argument in `label_kansuji()`.

### DIFF
--- a/R/label-kansuji.R
+++ b/R/label-kansuji.R
@@ -15,7 +15,8 @@
 #' @param big.mark Character used between every 3 digits to separate thousands.
 #' @param number If Number is arabic, it will return a mixture of Arabic and the
 #'  Kansuji Myriad Scale; if Kansuji, it will return only Kansuji numerals.
-#' @param ... Other arguments passed on to [base::prettyNum()] or [scales::label_number()].
+#' @param ... Other arguments passed on to [base::prettyNum()], [scales::label_number()] or
+#'  [arabic2kansuji::arabic2kansuji_all()].
 #' @rdname label_kansuji
 #'
 #' @return All `label_()` functions return a "labelling" function, i.e. a function
@@ -51,7 +52,7 @@ label_kansuji <- function(unit = NULL, sep = "", prefix = "", big.mark = "", num
     }
   }else if(number == "kansuji"){
     function(x){
-      x <- prettyNum(x, scientific = FALSE) %>% arabic2kansuji::arabic2kansuji_all()
+      x <- prettyNum(x, scientific = FALSE) %>% arabic2kansuji::arabic2kansuji_all(...)
       paste0(prefix, x, unit, sep = sep)
     }
   }

--- a/man/label_kansuji.Rd
+++ b/man/label_kansuji.Rd
@@ -36,7 +36,8 @@ label_kansuji_suffix(
 \item{number}{If Number is arabic, it will return a mixture of Arabic and the
 Kansuji Myriad Scale; if Kansuji, it will return only Kansuji numerals.}
 
-\item{...}{Other arguments passed on to \code{\link[base:formatc]{base::prettyNum()}} or \code{\link[scales:label_number]{scales::label_number()}}.}
+\item{...}{Other arguments passed on to \code{\link[base:formatc]{base::prettyNum()}}, \code{\link[scales:label_number]{scales::label_number()}} or
+\code{\link[arabic2kansuji:arabic2kansuji]{arabic2kansuji::arabic2kansuji_all()}}.}
 
 \item{accuracy}{A number to round to. Use (e.g.) 0.01 to show 2 decimal
 places of precision.}


### PR DESCRIPTION
`label_kansuji()`で`number = "kansuji"`としたとき、ラベルの数字を漢数字にするときに使用している`{arabic2kansuji}`の`arabic2kansuji_all()`の違和感のある変換挙動を一部変更し変換規則を引数で選択できるようにしたので、`label_kansuji()`でもその引数を（`...`で）受付け、内部の`arabic2kansuji_all()`に渡してもらえると、`label_kansuji()`でも漢数字の変換規則を変選択できるようになると思います。

具体的には`arabic2kansuji_all()`の挙動の変更としては110000000が入力されたときに、従来は「一億千万」と変換されていましたが、これを「一億一千万」に変換するようになりました。
ただし、この挙動の場合、15000000で「一千五百万」になりますが、「千五百万」も特に違和感がなくこれを選択できるように`add.one_thousand = FALSE`と引数で選択できるように準備しました。
また、1500は「千五百」になりますが、場合により「一千五百」もあり得るかと考え、これに変換できる`add.one_thousand.all`という引数を用意しました。
これらの引数を`label_kansuji()`で受け付けてもらえれば嬉しいです。

この変更をした`{arabic2kansuji}`はCRANに0.1.3として登録済みです。

機能提案のない軽微な変更ですが、ご検討いただければ幸いです。