### PR TITLE
Fixed a typo in the document and an error in the CRAN check that seems to have come from `@inheritDotParams`.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,4 +51,4 @@ Suggests:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2

--- a/R/kana.R
+++ b/R/kana.R
@@ -4,7 +4,7 @@
 #' Generates a vector consisting of the elements of kana.
 #' Options exist for the inclusion of several elements.
 #' @param type "hiragana" ("hira") or "katakana" ("kata")
-#' @inheritDotParams hiragana
+#' @param ... Arguments passed on to [hiragana]
 #' @rdname kana
 #' @examples
 #' kana(type = "hira", core = TRUE)
@@ -82,7 +82,6 @@ hiragana <- function(core = TRUE, dakuon = FALSE, handakuon = FALSE, kogaki = FA
                  intToUtf8)
 }
 
-#' @inheritParams hiragana
 #' @export
 #' @rdname kana
 katakana <- function(core = TRUE, dakuon = FALSE, handakuon = FALSE, kogaki = FALSE, historical = FALSE) {

--- a/R/label-kansuji.R
+++ b/R/label-kansuji.R
@@ -63,7 +63,7 @@ label_kansuji <- function(unit = NULL, sep = "", prefix = "", big.mark = "", num
 #' @param significant.digits Determines whether or not the value of accurary is
 #' valid as a significant figure with a decimal point. The default is FALSE, in
 #' which case if accurary is 2 and the value is 1.10, 1.1 will be displayed,
-#' but if TRUE and installed '{scales}` package, 1.10 will be displayed.
+#' but if TRUE and installed `{scales}` package, 1.10 will be displayed.
 #' @rdname label_kansuji
 #' @export
 label_kansuji_suffix <- function(accuracy = 1, unit = NULL, sep = NULL, prefix = "", big.mark = "", significant.digits = FALSE, ...) {

--- a/man/kana.Rd
+++ b/man/kana.Rd
@@ -27,11 +27,7 @@ katakana(
 \arguments{
 \item{type}{"hiragana" ("hira") or "katakana" ("kata")}
 
-\item{...}{
-  Arguments passed on to \code{\link[=hiragana]{hiragana}}
-  \describe{
-    \item{\code{}}{}
-  }}
+\item{...}{Arguments passed on to \link{hiragana}}
 
 \item{core}{is include core kana characters.}
 

--- a/man/label_kansuji.Rd
+++ b/man/label_kansuji.Rd
@@ -45,7 +45,7 @@ places of precision.}
 \item{significant.digits}{Determines whether or not the value of accurary is
 valid as a significant figure with a decimal point. The default is FALSE, in
 which case if accurary is 2 and the value is 1.10, 1.1 will be displayed,
-but if TRUE and installed '{scales}` package, 1.10 will be displayed.}
+but if TRUE and installed \code{{scales}} package, 1.10 will be displayed.}
 }
 \value{
 All \code{label_()} functions return a "labelling" function, i.e. a function


### PR DESCRIPTION
#56 に関連したプルリクエストです。