### PR TITLE
Fix for upcoming stringr 1.6.0

### DIFF
--- a/R/address.R
+++ b/R/address.R
@@ -68,12 +68,16 @@ separate_address <- function(str) {
                 paste0(city_name_regex, "(.+)"),
                 replacement = "\\1"))
       }
-      res <-
-        res %>%
-        purrr::list_merge(
-          street = split_pref[2] %>%
-            stringr::str_remove(res %>%
-                                  purrr::pluck("city")))
+      if (!is.na(res$city)) {
+        res <-
+          res %>%
+          purrr::list_merge(
+            street = split_pref[2] %>%
+              stringr::str_remove(res %>%
+                                    purrr::pluck("city")))
+      } else {
+        res$street <- NA_character_
+      }
       res %>%
         purrr::map(
           ~ dplyr::if_else(.x == "", NA_character_, .x)


### PR DESCRIPTION
`str_remove()` no longer accepts `NA` patterns since it's not clear what that means.